### PR TITLE
Add support for custom CDN URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,10 @@ The follow configuration settings are required and passed in to the 'setConfig' 
 - **##TEALIUM_ACCOUNT##** (String) Tealium iQ account
 - **##TEALIUM_PROFILE##** (String) Tealium iQ profile
 - **##TEALIUM_ENVIRONMENT##** (String) Tealium iQ environment ("dev", "qa", "prod")
+- **##TEALIUM_CDN##** (String) Tealium iQ CDN-URL (optional, Default value is 'https://tags.tiqcdn.com/utag/')
 
 ```javascript
   // The example in app.component.js shows how to configure
-  this.tealium.setConfig({ account: '##TEALIUM_ACCOUNT##', profile: '##TEALIUM_PROFILE##', environment: '##TEALIUM_ENVIRONMENT##' });
+  this.tealium.setConfig({ account: '##TEALIUM_ACCOUNT##', profile: '##TEALIUM_PROFILE##', environment: '##TEALIUM_ENVIRONMENT##', cdn: '##TEALIUM_CDN##' });
 ```
 

--- a/example/src/app/tealium/utag.service.ts
+++ b/example/src/app/tealium/utag.service.ts
@@ -37,9 +37,9 @@ export class TealiumUtagService {
   }
 
   // Config settings used to build the path to the utag.js file
-  setConfig(config: {account: string, profile: string, environment: string}) {
+  setConfig(config: {account: string, profile: string, environment: string, cdn: string = 'https://tags.tiqcdn.com/utag/'}) {
     if ( config.account !== undefined && config.profile !== undefined && config.environment !== undefined ) {
-      this.scriptSrc = 'https://tags.tiqcdn.com/utag/' + config.account + '/' + config.profile + '/' + config.environment + '/utag.js';
+      this.scriptSrc = config.cdn + config.account + '/' + config.profile + '/' + config.environment + '/utag.js';
     }
   }
 

--- a/example/src/app/tealium/utag.service.ts
+++ b/example/src/app/tealium/utag.service.ts
@@ -37,7 +37,8 @@ export class TealiumUtagService {
   }
 
   // Config settings used to build the path to the utag.js file
-  setConfig(config: {account: string, profile: string, environment: string, cdn: string = 'https://tags.tiqcdn.com/utag/'}) {
+  setConfig(config: {account: string, profile: string, environment: string, cdn?: string}) {
+    config.cdn = config.cdn || 'https://tags.tiqcdn.com/utag/';
     if ( config.account !== undefined && config.profile !== undefined && config.environment !== undefined ) {
       this.scriptSrc = config.cdn + config.account + '/' + config.profile + '/' + config.environment + '/utag.js';
     }


### PR DESCRIPTION
If you configure custom publish URLs, one needs to set a custom CDN-URL for the plugin, so the correct utag.js is loaded.